### PR TITLE
chore: add unit tests for data ingestion and scheduler modules

### DIFF
--- a/backend/app/__about__.py
+++ b/backend/app/__about__.py
@@ -1,3 +1,3 @@
 """Version info for Mailchimp Trends Engine app."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/backend/tests/unit/api/test_data_ingestion_router.py
+++ b/backend/tests/unit/api/test_data_ingestion_router.py
@@ -1,0 +1,47 @@
+"""Unit tests for the data ingestion API router."""
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from backend.app.server import app
+
+client = TestClient(app)
+
+
+def test_trigger_fetch_success():
+    """Test /api/v1/data-ingestion/trigger-fetch endpoint returns 202 on success."""
+    with patch(
+        "backend.app.api.v1.routers.data_ingestion.perform_scheduled_article_fetch",
+        new_callable=AsyncMock,
+    ):
+        response = client.post("/api/v1/data-ingestion/trigger-fetch")
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.json() == {
+            "message": "Article fetching job has been scheduled successfully."
+        }
+
+
+def test_trigger_fetch_error():
+    """
+    Test that the /api/v1/data-ingestion/trigger-fetch endpoint
+    returns 500 when an exception occurs before scheduling the background task.
+    """
+    # Mock BackgroundTasks.add_task to raise an exception directly
+    with patch(
+        "fastapi.BackgroundTasks.add_task",
+        side_effect=Exception("Test error"),
+    ):
+        # Disable the logging for cleaner test output
+        logging.disable(logging.ERROR)
+        try:
+            response = client.post("/api/v1/data-ingestion/trigger-fetch")
+            assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+            assert (
+                "Failed to schedule article fetching job" in response.json()["detail"]
+            )
+        finally:
+            # Re-enable logging
+            logging.disable(logging.NOTSET)

--- a/backend/tests/unit/data_ingestion/test_scheduler_lifecycle.py
+++ b/backend/tests/unit/data_ingestion/test_scheduler_lifecycle.py
@@ -1,0 +1,77 @@
+"""Unit tests for the scheduler module functionality."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest import LogCaptureFixture
+
+from backend.app.data_ingestion.scheduler import shutdown_scheduler, start_scheduler
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_start_scheduler_when_not_running():
+    """Test starting the scheduler when it's not already running."""
+    # Create a mock scheduler
+    mock_scheduler = MagicMock()
+    mock_scheduler.running = False
+
+    # Patch the scheduler reference in the module
+    with patch("backend.app.data_ingestion.scheduler.scheduler", mock_scheduler):
+        await start_scheduler()
+        mock_scheduler.start.assert_called_once()
+
+
+async def test_start_scheduler_when_already_running(caplog: LogCaptureFixture):
+    """Test starting the scheduler when it's already running."""
+    # Set the appropriate log level to capture INFO logs
+    caplog.set_level(logging.INFO)
+
+    # Create a mock scheduler
+    mock_scheduler = MagicMock()
+    mock_scheduler.running = True
+
+    # Patch the scheduler reference in the module
+    with patch("backend.app.data_ingestion.scheduler.scheduler", mock_scheduler):
+        await start_scheduler()
+
+        # Verify that start() wasn't called
+        mock_scheduler.start.assert_not_called()
+
+        # Verify the log message was generated
+        assert any(
+            "Scheduler is already running" in rec.message for rec in caplog.records
+        )
+
+
+async def test_shutdown_scheduler_when_running():
+    """Test shutting down the scheduler when it's running."""
+    # Create a mock scheduler
+    mock_scheduler = MagicMock()
+    mock_scheduler.running = True
+
+    # Patch the scheduler reference in the module
+    with patch("backend.app.data_ingestion.scheduler.scheduler", mock_scheduler):
+        await shutdown_scheduler()
+        mock_scheduler.shutdown.assert_called_once_with(wait=False)
+
+
+async def test_shutdown_scheduler_when_not_running(caplog: LogCaptureFixture):
+    """Test shutting down the scheduler when it's not running."""
+    # Set the appropriate log level to capture INFO logs
+    caplog.set_level(logging.INFO)
+
+    # Create a mock scheduler
+    mock_scheduler = MagicMock()
+    mock_scheduler.running = False
+
+    # Patch the scheduler reference in the module
+    with patch("backend.app.data_ingestion.scheduler.scheduler", mock_scheduler):
+        await shutdown_scheduler()
+
+        # Verify that shutdown() wasn't called
+        mock_scheduler.shutdown.assert_not_called()
+
+        # Verify the log message was generated
+        assert any("Scheduler is not running" in rec.message for rec in caplog.records)


### PR DESCRIPTION
# More unit tests - data ingestion - increase test coverage

## Summary
This PR introduces new unit tests for the data ingestion functionality in the backend. It adds test coverage for the API router endpoint responsible for triggering data ingestion and for the lifecycle management of the scheduler used in the data ingestion process.

## Files Changed
- **backend/tests/unit/api/test_data_ingestion_router.py**: Added a new test file to validate the behavior of the `/api/v1/data-ingestion/trigger-fetch` endpoint.
- **backend/tests/unit/data_ingestion/test_scheduler_lifecycle.py**: Added a new test file to ensure proper start and shutdown behavior of the data ingestion scheduler.

## Code Changes
- In `test_data_ingestion_router.py`:
  - Added tests for the `/api/v1/data-ingestion/trigger-fetch` endpoint to verify:
    - Successful scheduling returns a `202 Accepted` status.
    - An error during scheduling returns a `500 Internal Server Error`.
  ```python
  response = client.post("/api/v1/data-ingestion/trigger-fetch")
  assert response.status_code == status.HTTP_202_ACCEPTED
  ```
  - Mocked the background task execution to isolate the endpoint behavior.

- In `test_scheduler_lifecycle.py`:
  - Added tests for `start_scheduler` and `shutdown_scheduler` functions to handle cases when the scheduler is already running or not running.
  - Used `pytest.mark.asyncio` to support asynchronous testing.
  ```python
  async def test_start_scheduler_when_not_running():
      mock_scheduler = MagicMock()
      mock_scheduler.running = False
      with patch("backend.app.data_ingestion.scheduler.scheduler", mock_scheduler):
          await start_scheduler()
          mock_scheduler.start.assert_called_once()
  ```
  - Included logging checks to ensure appropriate feedback when the scheduler state prevents actions.

## Reason for Changes
These changes were made to improve the test coverage of the data ingestion module, a critical component for fetching and processing articles. Ensuring the reliability of the API endpoint and scheduler lifecycle management is essential for maintaining a robust data pipeline. The tests aim to catch potential issues in scheduling background tasks and managing the scheduler state.

## Impact of Changes
- **Functionality**: The addition of these tests does not alter the runtime behavior of the application but ensures that the data ingestion components behave as expected under various conditions.
- **Reliability**: Increased test coverage helps in identifying regressions or bugs in the data ingestion process early in the development cycle.
- **Maintainability**: Comprehensive tests make future refactoring or enhancements to the data ingestion module safer and more predictable.

## Test Plan
- The tests were written using `pytest` with `unittest.mock` for mocking dependencies.
- Run the test suite using `pytest backend/tests/` to verify that all tests pass.
- Ensure that the mocked components (`perform_scheduled_article_fetch`, `scheduler`) behave as expected by reviewing the test assertions and log outputs.

## Results on Coverage

### Before

![image](https://github.com/user-attachments/assets/9daf4b89-bf39-4fcb-9b0b-07fa89452955)

### After

![image](https://github.com/user-attachments/assets/28129162-30b2-4350-8df9-f5488705947a)


## Additional Notes
- These tests assume the existence of certain modules and functions (`perform_scheduled_article_fetch`, `start_scheduler`, `shutdown_scheduler`). If the actual implementation changes, the mocks and assertions may need updates.
- Potential bugs could arise if the real implementation of background task scheduling or scheduler lifecycle management diverges significantly from the mocked behavior. Keep an eye on integration tests to cover these scenarios.